### PR TITLE
Add minimum version of beeswarm (>= 0.4.0)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Suggests:
     rmarkdown,
     png,
     fda,
-    beeswarm,
+    beeswarm (>= 0.4.0),
     pkgdown
 License: GPL (>= 3)
 Language: en-US


### PR DESCRIPTION
The compact beeswarm layout is not available in versions below 0.4.0 of the `beeswarm` package; this PR adds `(>= 0.4.0)` as the version requirement for `beeswarm`.

Related issue: #64 