### PR TITLE
Control lower and upper limits with `expand` independently

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ New features and enhancements:
   bin width to fit within a desired area, it is probably better to use `scale`, 
   and if you want to provide constraints on the bin width, you can pass a 
   2-vector to `binwidth`.
+* The `expand` argument in `stat_slab()` can now take a length two logical 
+  vector to control expansion to the upper and lower limits respectively (#129).
 
 Bug fixes:
 

--- a/R/stat_slabinterval.R
+++ b/R/stat_slabinterval.R
@@ -226,10 +226,12 @@ compute_slab_sample = function(
   cdf_fun = weighted_ecdf(x)
   slab_df$cdf = cdf_fun(trans_input)
 
-  if (expand) {
-    # extend x values to the range of the plot. To do that we have to include
-    # x values requested from the original `input` if they are outside the
-    # range of the slab
+  # extend x values to the range of the plot. To do that we have to include
+  # x values requested from the original `input` if they are outside the
+  # range of the slab
+  expand <- rep_len(expand, 2L)
+
+  if (expand[[1]]) {
     input_below_slab = input[input < min(slab_df$.input)]
     if (length(input_below_slab) > 0) {
       slab_df = rbind(data.frame(
@@ -238,7 +240,8 @@ compute_slab_sample = function(
         cdf = 0
       ), slab_df)
     }
-
+  }
+  if (expand[[2]]) {
     input_above_slab = input[input > max(slab_df$.input)]
     if (length(input_above_slab) > 0) {
       slab_df = rbind(slab_df, data.frame(

--- a/R/stat_slabinterval.R
+++ b/R/stat_slabinterval.R
@@ -229,7 +229,7 @@ compute_slab_sample = function(
   # extend x values to the range of the plot. To do that we have to include
   # x values requested from the original `input` if they are outside the
   # range of the slab
-  expand <- rep_len(expand, 2L)
+  expand = rep_len(expand, 2L)
 
   if (expand[[1]]) {
     input_below_slab = input[input < min(slab_df$.input)]
@@ -378,6 +378,7 @@ compute_interval_slabinterval = function(
 #' @param trim For sample data, should the density estimate be trimmed to the range of the
 #' input data? Default `TRUE`.
 #' @param expand For sample data, should the slab be expanded to the limits of the scale? Default `FALSE`.
+#' Can be length two to control expansion to the lower and upper limit respectively.
 #' @param breaks If `slab_type` is `"histogram"`, the `breaks` parameter that is passed to
 #' [hist()] to determine where to put breaks in the histogram (for sample data).
 #' @param limits Manually-specified limits for the slab, as a vector of length two. These limits are combined with those

--- a/man/stat_ccdfinterval.Rd
+++ b/man/stat_ccdfinterval.Rd
@@ -113,7 +113,8 @@ group so that the maximum height in each group is \code{1}.
 only be used with functions whose values are in [0,1], such as CDFs).
 }}
 
-\item{expand}{For sample data, should the slab be expanded to the limits of the scale? Default \code{FALSE}.}
+\item{expand}{For sample data, should the slab be expanded to the limits of the scale? Default \code{FALSE}.
+Can be length two to control expansion to the lower and upper limit respectively.}
 
 \item{p_limits}{Probability limits (as a vector of size 2) used to determine the lower and upper
 limits of the slab. E.g., if this is \code{c(.001, .999)}, then a slab is drawn

--- a/man/stat_cdfinterval.Rd
+++ b/man/stat_cdfinterval.Rd
@@ -113,7 +113,8 @@ group so that the maximum height in each group is \code{1}.
 only be used with functions whose values are in [0,1], such as CDFs).
 }}
 
-\item{expand}{For sample data, should the slab be expanded to the limits of the scale? Default \code{FALSE}.}
+\item{expand}{For sample data, should the slab be expanded to the limits of the scale? Default \code{FALSE}.
+Can be length two to control expansion to the lower and upper limit respectively.}
 
 \item{p_limits}{Probability limits (as a vector of size 2) used to determine the lower and upper
 limits of the slab. E.g., if this is \code{c(.001, .999)}, then a slab is drawn

--- a/man/stat_eye.Rd
+++ b/man/stat_eye.Rd
@@ -126,7 +126,8 @@ is adjusted by multiplying it by this value. See \code{\link[=density]{density()
 \item{trim}{For sample data, should the density estimate be trimmed to the range of the
 input data? Default \code{TRUE}.}
 
-\item{expand}{For sample data, should the slab be expanded to the limits of the scale? Default \code{FALSE}.}
+\item{expand}{For sample data, should the slab be expanded to the limits of the scale? Default \code{FALSE}.
+Can be length two to control expansion to the lower and upper limit respectively.}
 
 \item{breaks}{If \code{slab_type} is \code{"histogram"}, the \code{breaks} parameter that is passed to
 \code{\link[=hist]{hist()}} to determine where to put breaks in the histogram (for sample data).}

--- a/man/stat_gradientinterval.Rd
+++ b/man/stat_gradientinterval.Rd
@@ -128,7 +128,8 @@ is adjusted by multiplying it by this value. See \code{\link[=density]{density()
 \item{trim}{For sample data, should the density estimate be trimmed to the range of the
 input data? Default \code{TRUE}.}
 
-\item{expand}{For sample data, should the slab be expanded to the limits of the scale? Default \code{FALSE}.}
+\item{expand}{For sample data, should the slab be expanded to the limits of the scale? Default \code{FALSE}.
+Can be length two to control expansion to the lower and upper limit respectively.}
 
 \item{breaks}{If \code{slab_type} is \code{"histogram"}, the \code{breaks} parameter that is passed to
 \code{\link[=hist]{hist()}} to determine where to put breaks in the histogram (for sample data).}

--- a/man/stat_halfeye.Rd
+++ b/man/stat_halfeye.Rd
@@ -126,7 +126,8 @@ is adjusted by multiplying it by this value. See \code{\link[=density]{density()
 \item{trim}{For sample data, should the density estimate be trimmed to the range of the
 input data? Default \code{TRUE}.}
 
-\item{expand}{For sample data, should the slab be expanded to the limits of the scale? Default \code{FALSE}.}
+\item{expand}{For sample data, should the slab be expanded to the limits of the scale? Default \code{FALSE}.
+Can be length two to control expansion to the lower and upper limit respectively.}
 
 \item{breaks}{If \code{slab_type} is \code{"histogram"}, the \code{breaks} parameter that is passed to
 \code{\link[=hist]{hist()}} to determine where to put breaks in the histogram (for sample data).}

--- a/man/stat_histinterval.Rd
+++ b/man/stat_histinterval.Rd
@@ -126,7 +126,8 @@ is adjusted by multiplying it by this value. See \code{\link[=density]{density()
 \item{trim}{For sample data, should the density estimate be trimmed to the range of the
 input data? Default \code{TRUE}.}
 
-\item{expand}{For sample data, should the slab be expanded to the limits of the scale? Default \code{FALSE}.}
+\item{expand}{For sample data, should the slab be expanded to the limits of the scale? Default \code{FALSE}.
+Can be length two to control expansion to the lower and upper limit respectively.}
 
 \item{breaks}{If \code{slab_type} is \code{"histogram"}, the \code{breaks} parameter that is passed to
 \code{\link[=hist]{hist()}} to determine where to put breaks in the histogram (for sample data).}

--- a/man/stat_slab.Rd
+++ b/man/stat_slab.Rd
@@ -107,7 +107,8 @@ is adjusted by multiplying it by this value. See \code{\link[=density]{density()
 \item{trim}{For sample data, should the density estimate be trimmed to the range of the
 input data? Default \code{TRUE}.}
 
-\item{expand}{For sample data, should the slab be expanded to the limits of the scale? Default \code{FALSE}.}
+\item{expand}{For sample data, should the slab be expanded to the limits of the scale? Default \code{FALSE}.
+Can be length two to control expansion to the lower and upper limit respectively.}
 
 \item{breaks}{If \code{slab_type} is \code{"histogram"}, the \code{breaks} parameter that is passed to
 \code{\link[=hist]{hist()}} to determine where to put breaks in the histogram (for sample data).}

--- a/man/stat_slabinterval.Rd
+++ b/man/stat_slabinterval.Rd
@@ -126,7 +126,8 @@ is adjusted by multiplying it by this value. See \code{\link[=density]{density()
 \item{trim}{For sample data, should the density estimate be trimmed to the range of the
 input data? Default \code{TRUE}.}
 
-\item{expand}{For sample data, should the slab be expanded to the limits of the scale? Default \code{FALSE}.}
+\item{expand}{For sample data, should the slab be expanded to the limits of the scale? Default \code{FALSE}.
+Can be length two to control expansion to the lower and upper limit respectively.}
 
 \item{breaks}{If \code{slab_type} is \code{"histogram"}, the \code{breaks} parameter that is passed to
 \code{\link[=hist]{hist()}} to determine where to put breaks in the histogram (for sample data).}

--- a/tests/testthat/test.stat_sample_slabinterval.R
+++ b/tests/testthat/test.stat_sample_slabinterval.R
@@ -245,3 +245,32 @@ test_that("trim and expand work", {
       stat_sample_slabinterval(n = 15, slab_color = "black", expand = TRUE, trim = FALSE)
   )
 })
+
+test_that("expand can take length two vector", {
+
+  set.seed(1234)
+  df = data.frame(
+    g = c("a","a","a","b"),
+    x = runif(120, c(1,1,1,2), c(2,2,2,3))
+  )
+
+  p <- df %>%
+    ggplot(aes(x = x, y = g)) +
+    lims(x = c(0, 4))
+
+  ld <- layer_data(p + stat_ccdfinterval(expand = c(TRUE, TRUE)))
+  expect_lt(min(ld$x, na.rm = TRUE), 1)
+  expect_gt(max(ld$x, na.rm = TRUE), 3)
+
+  ld <- layer_data(p + stat_ccdfinterval(expand = c(TRUE, FALSE)))
+  expect_lt(min(ld$x,  na.rm = TRUE), 1)
+  expect_lte(max(ld$x, na.rm = TRUE), 3)
+
+  ld <- layer_data(p + stat_ccdfinterval(expand = c(FALSE, TRUE)))
+  expect_gte(min(ld$x, na.rm = TRUE), 1)
+  expect_gt(max(ld$x,  na.rm = TRUE), 3)
+
+  ld <- layer_data(p + stat_ccdfinterval(expand = c(FALSE, FALSE)))
+  expect_gte(min(ld$x, na.rm = TRUE), 1)
+  expect_lte(max(ld$x, na.rm = TRUE), 3)
+})


### PR DESCRIPTION
Hi Matthew, 

This is the PR discussed in #129 with respect to the `expand` argument.
A brief overview:

* `expand` can now be a length 2 logical vector
  * If user inputs a length 1 vector, it gets recycled to length 2, giving the exact same behaviour as before this PR. 
* Previously the expansion was one logic branch. Now these are two logic branches for the lower and upper limits separately.

Best,
Teun