### PR TITLE
`guide_rampbar()` compatibility with ggplot2 >3.4.2

### DIFF
--- a/R/guide_rampbar.R
+++ b/R/guide_rampbar.R
@@ -58,6 +58,21 @@
 #' @export
 guide_rampbar = function(..., to = "gray65", available_aes = c("fill_ramp", "colour_ramp")) {
   guide = guide_colourbar(..., available_aes = available_aes)
+  if (inherits(guide, "GuideColourbar")) {
+    # If ggplot2 >3.4.2, guides are written ggproto, so here we inherit from
+    # the colourbar guide
+    new = ggproto(
+      "GuideRampbar", guide,
+      params = c(list(to = to), guide$params),
+      extract_decor = function(scale, aesthetic, nbin = 300,
+                               reverse = FALSE, to = "grey65", ...) {
+        bar = guide$extract_decor(scale, aesthetic, nbin, reverse, ...)
+        bar$colour = apply_colour_ramp(to, bar$colour)
+        bar
+      }
+    )
+    return(new)
+  }
   guide$to = to
   class(guide) = c("guide", "rampbar", "colorbar")
   guide

--- a/R/guide_rampbar.R
+++ b/R/guide_rampbar.R
@@ -65,7 +65,7 @@ guide_rampbar = function(..., to = "gray65", available_aes = c("fill_ramp", "col
       "GuideRampbar", guide,
       params = c(list(to = to), guide$params),
       extract_decor = function(scale, aesthetic, nbin = 300,
-                               reverse = FALSE, to = "grey65", ...) {
+                               reverse = FALSE, to = "gray65", ...) {
         bar = guide$extract_decor(scale, aesthetic, nbin, reverse, ...)
         bar$colour = apply_colour_ramp(to, bar$colour)
         bar


### PR DESCRIPTION
Hello Matthew,

Apologies for the cold PR without posting an issue first.
The ggplot2 package has changed the implementation of the guide system, which means that the old S3 system will no longer work, see ggplot2's [news file](https://github.com/tidyverse/ggplot2/blob/2a7ca74e297cdc23c56ce34fef193d5a6b488292/NEWS.md?plain=1#L29-L59). Unfortunately, the new guides aren't fully backwards compatible with old guides, so I'm going around trying to preserve guide extensions.

This PR makes `guide_rampbar()` compatible with the development version of ggplot2 while it also preserves functionality in earlier versions. 

Best,
Teun

P.S.: I noticed in the unit tests the warning message tested with `"Removed 1 rows containing"` has changed, but that is unrelated to this PR, just as a heads up.