### PR TITLE
`use_defaults()` method passes extra arguments

### DIFF
--- a/R/abstract_geom.R
+++ b/R/abstract_geom.R
@@ -143,7 +143,7 @@ AbstractGeom = ggproto("AbstractGeom", Geom,
 
   ## other methods -----------------------------------------------------------
 
-  use_defaults = function(self, data, params = list(), modifiers = aes()) {
+  use_defaults = function(self, data, params = list(), modifiers = aes(), ...) {
     # we must provide our own check for Geom$rename_size because our fallbacks
     # from default_aes to default_key_aes require us to be able to have a non-missing
     # (but NULL) linewidth aesthetic in default_aes, which ggplot2::Geom$use_defaults
@@ -154,7 +154,7 @@ AbstractGeom = ggproto("AbstractGeom", Geom,
     }
     rename_size = self$rename_size
     self$rename_size = FALSE
-    out = ggproto_parent(Geom, self)$use_defaults(data, params, modifiers)
+    out = ggproto_parent(Geom, self)$use_defaults(data, params, modifiers, ...)
     self$rename_size = rename_size
     out
   }


### PR DESCRIPTION
Hi Matthew,

Pardon for the cold PR!
We discovered through reverse dependency checks that the way {ggdist}'s `use_defaults()` method is implemented is incompatible with a new feature we're planning for {ggplot2}.
The new feature is described in https://github.com/tidyverse/ggplot2/pull/5833, but the TL;DR is that we want to allow geoms to derive their default aesthetics from a theme element.

This PR aims to make {ggdist} compatible that feature in {ggplot2}.
We aim to include that feature in the next version of ggplot2, which isn't scheduled to come out until next year.
I'd be happy to provide more context if needed!

Here is an example of {ggdist} + the new feature in action.

``` r
devtools::load_all("~/packages/test/ggdist/") # this PR
#> ℹ Loading ggdist
library(ggplot2)
packageVersion("ggplot2") # from the linked PR
#> [1] '3.5.1.9000'

df <- data.frame(x = rnorm(1000))

# Set default fill to be derived from theme
update_geom_defaults("slabinterval", aes(fill = from_theme(accent)))

# Using theme to set the default accent colour for geoms
ggplot(df, aes(x)) +
  stat_halfeye() +
  theme(geom = element_geom(accent = "dodgerblue"))
```

![](https://i.imgur.com/dheFubh.png)<!-- -->

<sup>Created on 2024-07-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
