### PR TITLE
Update test for plotting n quantiles from missing distribution

### DIFF
--- a/tests/testthat/test.geom_dotsinterval.R
+++ b/tests/testthat/test.geom_dotsinterval.R
@@ -180,7 +180,7 @@ test_that("stat_dist_dots works on NA data", {
     vdiffr::expect_doppelganger("stat_dist_dots with na.rm = FALSE",
       p + stat_dist_dots(na.rm = FALSE, quantiles = 20)
     ),
-    "Removed 1 row"
+    "Removed 20 rows"
   )
 
   vdiffr::expect_doppelganger("stat_dist_dots with na.rm = TRUE",


### PR DESCRIPTION
Some improvements in the upcoming release of `{distributional}` has made an intentional change which has broken one of your unit tests.

When requesting 20 quantiles from a missing distribution, it previously gave 1 result but it now gives 20 as is the case for other distributions.