### PR TITLE
Use `median` for ribbon order heuristic

### DIFF
--- a/R/geom_lineribbon.R
+++ b/R/geom_lineribbon.R
@@ -232,7 +232,7 @@ GeomLineribbon = ggproto("GeomLineribbon", AbstractGeom,
         GeomRibbon$draw_panel(transform(d, linewidth = NA), panel_scales, coord, flipped_aes = flipped_aes)
       )
       list(
-        order = mean(d[["order"]], na.rm = TRUE),
+        order = median(d[["order"]], na.rm = TRUE),
         grobs = group_grobs
       )
     })


### PR DESCRIPTION
Closes https://github.com/mjskay/ggdist/issues/255.

Existing tests pass with this change. Leaving as a Draft, as I have not implemented a new test based on the fix.