### PR TITLE
Pass na.rm through to quantile.distribution()

### DIFF
--- a/R/point_interval.R
+++ b/R/point_interval.R
@@ -397,8 +397,7 @@ qi_ = function(x, lower_prob, upper_prob, na.rm) {
   }
 
   if (distributional::is_distribution(x)) {
-    #TODO: when #114 / distributional#72 is fixed, pass na.rm to quantile in this call
-    do.call(rbind, lapply(quantile(x, c(lower_prob, upper_prob)), t))
+    do.call(rbind, lapply(quantile(x, c(lower_prob, upper_prob), na.rm = na.rm), t))
   } else {
     matrix(quantile(x, c(lower_prob, upper_prob), na.rm = na.rm, names = FALSE), ncol = 2)
   }


### PR DESCRIPTION
Resolves #114

This seemed to be a simple improvement (pending long finished `{distributional}` changes) that I came across while I was working on revdep checks.