### PR TITLE
Use marginal quantiles for multivariate distributional distributions

### DIFF
--- a/R/distributions.R
+++ b/R/distributions.R
@@ -425,7 +425,7 @@ cdf.ggdist__weighted_sample = function(x, q, ..., na.rm = TRUE) {
 }
 
 #' @export
-quantile.ggdist__weighted_sample = function(x, p, ..., na.rm = TRUE, names = FALSE) {
+quantile.ggdist__weighted_sample = function(x, p, ..., na.rm = TRUE, names = FALSE, kind = "marginal") {
   weighted_quantile(x[["x"]], p, weights = x[["weights"]], ..., na.rm = na.rm, names = names)
 }
 

--- a/R/point_interval.R
+++ b/R/point_interval.R
@@ -397,8 +397,7 @@ qi_ = function(x, lower_prob, upper_prob, na.rm) {
   }
 
   if (distributional::is_distribution(x)) {
-    #TODO: when #114 / distributional#72 is fixed, pass na.rm to quantile in this call
-    do.call(rbind, lapply(quantile(x, c(lower_prob, upper_prob)), t))
+    do.call(rbind, lapply(quantile(x, c(lower_prob, upper_prob), na.rm = na.rm), t))
   } else {
     matrix(quantile(x, c(lower_prob, upper_prob), na.rm = na.rm, names = FALSE), ncol = 2)
   }

--- a/R/point_interval.R
+++ b/R/point_interval.R
@@ -397,7 +397,7 @@ qi_ = function(x, lower_prob, upper_prob, na.rm) {
   }
 
   if (distributional::is_distribution(x)) {
-    do.call(rbind, lapply(quantile(x, c(lower_prob, upper_prob), na.rm = na.rm), t))
+    do.call(rbind, lapply(quantile(x, c(lower_prob, upper_prob), kind = "marginal", na.rm = na.rm), t))
   } else {
     matrix(quantile(x, c(lower_prob, upper_prob), na.rm = na.rm, names = FALSE), ncol = 2)
   }


### PR DESCRIPTION
As discussed in https://github.com/mitchelloharawild/distributional/issues/144, the `{distributional}` package will be changing the default quantiles for multivariate distributions from marginal to equicoordinate in v0.7.0.

This PR (merge #270 first) prepares `{ggdist}` for this breaking change, by explicitly using marginal quantiles for all distributional distributions.