### PR TITLE
Fix NA density value when a bound coincides with an extremum of x

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,9 @@ Internal changes:
 
 Bug fixes:
 
+* `density_bounded()` no longer returns an `NA` density value when a bound is
+  equal to the corresponding extremum of `x`, which made downstream summaries
+  like `hdi()` and `mode_hdi()` fail (#269; reported by @ASKurz).
 * `geom_lineribbon()` draw order now uses `median()` instead of `mean()` to
   determine order from the `order` aesthetic to be robust to infinities 
   (#255; thanks @damonbayer).

--- a/R/density.R
+++ b/R/density.R
@@ -246,7 +246,11 @@ density_bounded = auto_partial(name = "density_bounded", function(
   range_x = range(x)
   if (isTRUE(trim) && (bounds[[1]] < range_x[[1]] || bounds[[2]] > range_x[[2]])) {
     x_trimmed = seq.int(range_x[[1]], range_x[[2]], length.out = n)
-    f = approx(d$x, f, x_trimmed)$y
+    # rule = 2 because when a bound is equal to the corresponding extremum of x,
+    # floating point error in the construction of d$x can leave it short of that
+    # bound by a few ulp, putting the endpoint of x_trimmed just outside the
+    # interpolation range and yielding NA (#269)
+    f = approx(d$x, f, x_trimmed, rule = 2)$y
     d$x = x_trimmed
   }
 

--- a/tests/testthat/test.density.R
+++ b/tests/testthat/test.density.R
@@ -28,6 +28,22 @@ test_that("density_bounded works", {
   expect_error(density_bounded(c(1, 2, NA)), "must not contain missing \\(NA\\) values")
 })
 
+test_that("density_bounded does not return NAs when a bound is an extremum of x", {
+  # when a bound is equal to the corresponding extremum of x, floating point error
+  # in the construction of the internal grid can leave it a few ulp short of that
+  # bound, putting the endpoint of the trimmed grid outside the interpolation
+  # range and yielding NA (#269)
+  x = c(0.5, 1, 1.5, 2)
+  bounds = c(0.1, 2)
+
+  d = density_bounded(x, bounds = bounds)
+  expect_false(anyNA(d$y))
+  expect_equal(max(d$x), max(x))
+
+  # the NA made downstream summaries fail
+  expect_no_error(hdi(x, density = density_bounded(bounds = bounds)))
+})
+
 test_that("density_unbounded works", {
   x = 1:10
 


### PR DESCRIPTION
Closes #269.

### The cause

`density_bounded()` trims by interpolating the reflected density onto `seq(min(x), max(x), length.out = n)`:

```r
x_trimmed = seq.int(range_x[[1]], range_x[[2]], length.out = n)
f = approx(d$x, f, x_trimmed)$y
```

`d$x` is a slice of the wider grid `seq(bounds[[1]] - width, bounds[[2]] + width, length.out = n_unbounded)`, so its endpoints reproduce `bounds` only up to floating point error. When a bound happens to equal the corresponding extremum of `x`, that error is enough to break the interpolation: `x_trimmed` ends exactly at `max(x)`, `d$x` ends a couple of ulp below it, and `approx()` returns `NA` for that last point.

In @ASKurz's reprex the discovered upper bound is exactly `max(x) = 1`, and the grid lands at `0.99999999999999978`, short by `2.22e-16`. That single `NA` then reaches `quantile()` inside `hdi()`, which is where the error surfaces:

```
Error in quantile.default(dist_y, probs = 1 - .width, names = FALSE) :
  missing values and NaN's not allowed if 'na.rm' is FALSE
```

A smaller deterministic reproducer, no sampling involved:

```r
density_bounded(c(0.5, 1, 1.5, 2), bounds = c(0.1, 2))$y |> anyNA()
#> [1] TRUE
```

### The fix

`approx(..., rule = 2)`. The `trim` branch only runs when `bounds` already contains `range(x)`, so anything outside the interpolation range is floating point noise at the endpoints, and constant extrapolation over a few ulp is exact to the precision available. This leaves the returned `x` grid unchanged, so `trim` still means "the output spans exactly the range of the data".

I considered clamping `x_trimmed` to `range(d$x)` instead, but that would make the returned grid stop just short of `max(x)` and quietly weaken what `trim` promises.

### Tests

Added a regression test using the deterministic reproducer above. It fails on `main` with both the `NA` and the `hdi()` error, and passes with the fix. `test.density.R` and `test.point_interval.R` pass; the remaining failures in the full suite are the pre-existing vdiffr snapshot differences from #272, which also fail on a clean checkout here.

One thing I noticed while testing, not addressed here since it is a separate question: on the reprex's `p^3` posterior, whose true density is monotone, `hdi()` now returns two disjoint intervals rather than one. That looks like ordinary noise in the density estimate creating a shallow local minimum, not a bug in this code path, but it may be worth a look if you think the density should be smooth enough there to avoid splitting.
