### PR TITLE
Keep floating point error in normalized weights from adding a replicate in weighted_quantile(n = ...)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,10 @@ Internal changes:
 
 Bug fixes:
 
+* `weighted_quantile()` with an effective sample size (`n`) is no longer thrown
+  off by floating point error in the normalized weights, which could add a
+  spurious replicate and break the correspondence with `quantile()` that `n` is
+  meant to provide (#267).
 * `geom_lineribbon()` draw order now uses `median()` instead of `mean()` to
   determine order from the `order` aesthetic to be robust to infinities 
   (#255; thanks @damonbayer).

--- a/R/weighted_quantile.R
+++ b/R/weighted_quantile.R
@@ -162,7 +162,12 @@ weighted_quantile_fun = function(x, weights = NULL, n = NULL, na.rm = FALSE, typ
     # to each point in the weighted sample (rounding up). This is the number of
     # replicates of that point we will use to represent that point to create
     # flat regions in the approximate inverse CDF.
-    n_rep = ceiling(weights * n)
+    # the tolerance keeps weights that are exact multiples of 1/n from being
+    # rounded up to the next integer: normalizing counts from a summarised
+    # sample can leave weights * n a few ulp above a whole number, which would
+    # add a spurious replicate and break the correspondence with quantile()
+    # that `n` is meant to provide
+    n_rep = pmax(1, ceiling(weights * n * (1 - sqrt(.Machine$double.eps))))
     x = rep.int(x, n_rep)
     f_x = rep.int(weights / n_rep, n_rep)
   }

--- a/tests/testthat/test.weighted_quantile.R
+++ b/tests/testthat/test.weighted_quantile.R
@@ -27,6 +27,23 @@ test_that("weighted_quantile is equivalent to quantile on weighted samples", {
   }
 })
 
+test_that("weighted_quantile with n is robust to rounding in the normalized weights", {
+  # normalizing counts from a summarised sample can leave weights * n a few ulp
+  # above a whole number (here 7/25 * 25), which rounded up to a spurious
+  # replicate and broke the correspondence with quantile() (#267)
+  x = rep(1:3, times = c(10, 8, 7))
+  xw = 1:3
+  w = c(10, 8, 7)
+
+  p = ppoints(20, a = 1)
+  for (type in 1:9) {
+    expect_equal(
+      weighted_quantile(xw, p, weights = w, n = "sum", type = !!type),
+      quantile(x, p, type = !!type)
+    )
+  }
+})
+
 test_that("na.rm works", {
   expect_equal(
     weighted_quantile(c(1:4, NA), weights = c(4:2, NA, 1), ppoints(10), na.rm = TRUE),


### PR DESCRIPTION
Found while working through #267. This is a separate, narrower bug, so I've split it out rather than mixing it into that discussion.

### The problem

The docs for `n` promise that summarising a sample with duplicates into a weighted sample and then passing the original sample size gives back `quantile()` on the original sample. That breaks on some inputs:

```r
x = rep(1:3, times = c(10, 8, 7))

quantile(x, 0.75, type = 4, names = FALSE)
#> [1] 2.75
weighted_quantile(1:3, 0.75, weights = c(10, 8, 7), n = 25, type = 4, names = FALSE)
#> [1] 2.857143
```

The weights are normalized to `weights / sum(weights)`, then expanded with `n_rep = ceiling(weights * n)`. For the third group that round trip is not exact:

```r
7/25 * 25
#> [1] 7
print(7/25 * 25, digits = 17)
#> [1] 7.0000000000000009
```

so `ceiling()` returns 8 instead of 7. That group gets an extra replicate, the total becomes 26 rather than 25, and every `p_k` downstream shifts.

Sweeping 500 random integer samples across types 4–9 (3000 comparisons), 1.0% disagree with `quantile()` on the original sample. The existing test for this correspondence happens to use counts `4:1`, whose normalization is exact, so it doesn't catch it.

### The fix

Shrink by a relative tolerance before rounding up, so weights that are exact multiples of `1/n` stay put:

```r
n_rep = pmax(1, ceiling(weights * n * (1 - sqrt(.Machine$double.eps))))
```

`pmax(1, ...)` keeps very small weights from being shrunk to zero replicates, which would drop the point entirely. After the change the same 3000-comparison sweep has no mismatches.

### Tests

Added a regression test alongside the existing equivalence test, using counts that do trigger the rounding. It fails on `main` for types 4, 5, 7, and 9, and passes with the fix. `test.weighted_quantile.R`, `test.weighted_ecdf.R`, `test.weighted_hist.R`, and `test.point_interval.R` all pass.

Worth noting the tolerance is a pragmatic fix at the point of rounding, not a change to how weights are represented. If you'd rather have the expansion work from unnormalized weights (where counts stay exact), that would be a more structural fix, and I'm happy to redo it that way.
