### PR TITLE
Document the default point and intervals in the slabinterval vignette

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,12 @@ Minor changes:
   and particularly makes small, isolated clusters less likely to appear lopsided
   (inspired by a question from @jbengler at the ggextenders talk).
 
+Documentation:
+
+* `vignette("slabinterval")` now says what the point and the intervals in a
+  half-eye plot are by default, how `.width` relates to the quantiles at the
+  ends of a quantile interval, and how the result differs from a boxplot (#257).
+
 Internal changes:
 
 * Ensure duplicate points in paths are removed before drawing (e.g. when slabs

--- a/vignettes/slabinterval.Rmd
+++ b/vignettes/slabinterval.Rmd
@@ -353,6 +353,23 @@ df %>%
   ggtitle("stat_halfeye() (or stat_slabinterval())")
 ```
 
+#### What the point and the intervals are by default
+
+The point is the **median** and the two line widths are the **66% and 95% quantile intervals**. Those come from two arguments shared by the whole slabinterval family: `point_interval = median_qi` selects the point summary and the interval estimator, and `.width = c(.66, .95)` selects how much probability mass each interval covers. Passing them explicitly gives the same plot as the defaults:
+
+```{r halfeye_defaults, fig.width = tiny_height, fig.height = tiny_height}
+df %>%
+  ggplot(aes(y = group, x = value)) +
+  stat_halfeye(point_interval = median_qi, .width = c(.66, .95)) +
+  ggtitle("the defaults, written out")
+```
+
+Intervals are specified by the mass they contain rather than by the quantiles at their ends, because that definition also covers estimators whose intervals are not equi-tailed and may not even be contiguous, such as the highest-density interval `median_hdi()`. For quantile intervals you can convert between the two: an interval covering mass \(w\) is the equi-tailed interval running from quantile \((1 - w)/2\) to \((1 + w)/2\), so the 95% quantile interval ends at the 2.5th and 97.5th percentiles, and the 66% interval ends at the 17th and 83rd.
+
+This is not the same summary a boxplot draws. A boxplot's box is the interquartile range, which in these terms is the 50% quantile interval, and its whiskers extend to the most extreme observation within 1.5 IQR of the box, which is a rule about the observed data rather than a fixed amount of probability mass. So the box is narrower than the inner interval here, and the whiskers have no exact `.width` equivalent.
+
+Other point summaries and interval estimators are available, including `mean_qi()`, `mode_hdi()`, and `median_hdci()`; see `point_interval()` for the full set.
+
 We can use the `side` parameter to more finely control where the slab (in this case, the density) is drawn;
 `stat_eye()` is also a shortcut for `stat_slabinterval(side = "both")`, as it creates "eye" plots:
 


### PR DESCRIPTION
Closes #257. This takes the first of the two TODOs you listed there, the vignette one, and leaves the `point_interval()` reference overhaul alone.

The section goes into `vignette("slabinterval")` right after the first half-eye plot, which is where a reader first sees the point and the two line widths and wonders what they are. It covers:

- the defaults, stated plainly: median, 66% and 95% quantile intervals, coming from `point_interval = median_qi` and `.width = c(.66, .95)`, with a figure passing both explicitly to show it reproduces the default plot;
- why intervals are specified by contained mass rather than by their endpoints, which is your explanation in the issue, kept short and pointing at `median_hdi()` as the case that motivates it;
- the conversion for quantile intervals, so a reader who does want percentiles can get them: mass \(w\) runs from \((1-w)/2\) to \((1+w)/2\), hence 2.5/97.5 and 17/83;
- how this differs from a boxplot, since that is the comparison in the original report. The box is the 50% quantile interval, and the whiskers are a rule about observed data rather than a fixed mass, so they have no `.width` equivalent. I left out the 99.3% Normal-reference approximation, since you noted you wouldn't recommend it and it seemed likelier to invite the comparison than settle it.

Checked before writing: explicit `point_interval = median_qi, .width = c(.66, .95)` produces layer data identical to the defaults, the 95% and 66% interval endpoints match `quantile()` at those percentiles, and the point equals the median. The vignette renders.

Happy to cut it down, move it, or drop the boxplot part if you'd rather that lived elsewhere.
